### PR TITLE
Fix TypeScript Support section in api-hooks

### DIFF
--- a/docs/api-hooks.md
+++ b/docs/api-hooks.md
@@ -26,7 +26,7 @@ type MyApplicationContext = {
 }
 
 function MyComponent() {
-    const context = useApplicationContext();
+    const context = useApplicationContext<MyApplicationContext>();
     
     return <Text>{context.key}</Text>
 }


### PR DESCRIPTION
I think this was just a mistaken omission?